### PR TITLE
Player prefab camera adjusted to fix rotation issue

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -26,13 +26,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5449028411085845421}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0.13052616, y: 0, z: 0, w: 0.9914449}
   m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8805941940359490115}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 15, y: 0, z: 0}
 --- !u!20 &1553984238254788714
 Camera:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Changed:
- Rather than the Player root object being rotated, the prefab's camera has a rotation placed on its pitch (down 15 degrees)
- This rotation could be set at runtime in the inspector or changed
- Will remain independent of the root Player yaw rotation

Note:
- In the main scene (or any copied from it) the Player prefab used in the scene will need to have the pitch override removed